### PR TITLE
[feat] add clear_db option

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,8 @@ from argparse import ArgumentParser
 import dotenv
 import nest_asyncio
 
+from pyoniverse.db.client import DBClient
+
 
 parser = ArgumentParser(
     prog="Pyoniverse Crawler",
@@ -15,6 +17,11 @@ parser.add_argument(
 )
 parser.add_argument(
     "--stage", type=str, default="test", choices=["dev", "prod", "test"], required=True
+)
+parser.add_argument(
+    "--clear_db",
+    action="store_true",
+    help="crawling_* DB 데이터 삭제. ETL Pipeline 상에서 동작할 때 사용. " "spider=all 이어야 한다",
 )
 
 nest_asyncio.apply()
@@ -32,4 +39,7 @@ if __name__ == "__main__":
     if args.spider != "all":
         SingleRunner.run(spider=args.spider, loglevel=loglevel, stage=args.stage)
     else:
+        if args.clear_db:
+            client = DBClient.instance()
+            client.clear()
         AllRunner.run(loglevel=loglevel, stage=args.stage)

--- a/pyoniverse/db/client.py
+++ b/pyoniverse/db/client.py
@@ -1,0 +1,51 @@
+import os
+from time import sleep
+
+from pymongo import MongoClient, WriteConcern
+
+
+class DBClient:
+    """
+    최초 실행된 인스턴스로 고정
+    """
+
+    __instance = None
+
+    @classmethod
+    def __get_instance(cls, *args, **kwargs) -> "DBClient":
+        """
+        URI: connection uri
+        DB: db name
+        """
+        return cls.__instance
+
+    @classmethod
+    def instance(cls, *args, **kwargs) -> "DBClient":
+        """
+        URI: connection uri
+        DB: db name
+        """
+        cls.__instance = cls(*args, **kwargs)
+        # 이후 instance 실행에서 변경 불가능하게
+        cls.instance = cls.__get_instance
+        return cls.__instance
+
+    def __init__(self, *args, **kwargs):
+        """
+        URI: connection uri
+        DB: db name
+        """
+        self.__client = MongoClient(kwargs.get("URI", os.getenv("MONGO_URI")))
+        self.__db = kwargs.get("DB", os.getenv("MONGO_DB"))
+
+    def clear(self):
+        """
+        DB의 모든 컬렉션 데이터 제거
+        """
+        write_db = self.__client.get_database(
+            self.__db, write_concern=WriteConcern(w="majority", wtimeout=30)
+        )
+        for col in write_db.list_collection_names():
+            write_db.get_collection(col).delete_many({})
+            sleep(10)
+        return


### PR DESCRIPTION
- Crawling 시작 전, 데이터를 전부 삭제할 수 있는 방법 추가 `--clear_db`(spider=all 과 함께 사용해야 한다)
- ex) `python main.py --stage=dev --clear_db all`
