### PR TITLE
[fix] cuweb_event spider

### DIFF
--- a/pyoniverse/spiders/cuweb_event.py
+++ b/pyoniverse/spiders/cuweb_event.py
@@ -40,7 +40,10 @@ class CUWebEventSpider(Spider):
                 datetime.strptime(event["evtEYmd"], "%Y%m%d"),
             )
             if not event["bannerImg"].startswith("http"):
-                banner = str(Path(self.img_base_url) / event["bannerImg"])
+                if event["bannerImg"].startswith("/"):
+                    banner = str(self.img_base_url + event["bannerImg"])
+                else:
+                    banner = str(self.img_base_url + "/" + event["bannerImg"])
             else:
                 banner = event["bannerImg"]
             title = event["prdDispNm"]
@@ -60,11 +63,18 @@ class CUWebEventSpider(Spider):
     def parse(self, response: Response, **kwargs) -> BrandEventVO:
         soup = BeautifulSoup(response.text, "html.parser")
         event = soup.select_one(".event_area")
-        imgs = [
-            "https:" + i["src"]
-            for i in event.select("img")
-            if not i["src"].startswith("http")
-        ]
+        imgs = []
+        for i in event.select("img"):
+            if i["src"].startswith("http"):
+                imgs.append(i["src"])
+                continue
+            elif i["src"].startswith("//"):
+                imgs.append("https:" + i["src"])
+                continue
+            elif i["src"].startswith("/"):
+                imgs.append("https:/" + i["src"])
+            elif i["src"].startswith(":"):
+                imgs.append("https" + i["src"])
         # description = event.get_text().strip()
         # description = re.sub(r"(\s)+", r"\1", description)
 


### PR DESCRIPTION
1. `idna empty domain` 오류 발생
2. `twisted` 에서 사용하는 idna가 invalid domain name에 대해 그런 오류를 발생시킬 수 있다는 포스트 발견([링크](https://github.com/scrapy/scrapy/issues/3321))
3. idna 오류로 판단하여 디버깅을 시도했으나, 실제로는 `cuweb_events`에서 `://...` `/...` `//...` `https://...` 등 다양한 형식으로 이미지 링크를 저장하고 있어 이것을 파싱하지 못해 생긴 문제
4. `cuweb_spider` 수정.

## PS
1. ImagePipeline에서 size와 thumb 등을 재조정